### PR TITLE
Add unique_id configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Configuration variables:
 - **entities** (*Required*): A list of entity IDs that you want to read attributes from.
 - **attribute** (*Required*): Which attribute to extract from defined entity IDs.
 - **friendly_name** (*Optional*): Name to use in the Frontend *(will be the same for all entities specified)*.
+- **unique_id** (*Optional*): Custom unique ID prefix for the sensors. If provided, the unique ID will be formatted as `{unique_id}_{entity_name}_{attribute}`. If not specified, an auto-generated unique ID will be used.
 - **icon** (*Optional*): Icon to use in the Frontend.
 - **device_class** (*Optional*): Defines the device_class, if not specified it will be the same as parent.
 - **unit_of_measurement** (*Optional*): Defines the units of measurement of the sensor, if any.

--- a/custom_components/attributes/sensor.py
+++ b/custom_components/attributes/sensor.py
@@ -17,6 +17,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
+    CONF_UNIQUE_ID,
     CONF_UNIT_OF_MEASUREMENT,
     ATTR_ICON,
     CONF_ENTITIES,
@@ -52,6 +53,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_ROUND_TO): cv.positive_int,
         vol.Optional(CONF_VALUE_TEMPLATE): cv.string,
         vol.Optional(CONF_STATE_CLASS): STATE_CLASSES_SCHEMA,
+        vol.Optional(CONF_UNIQUE_ID): cv.string,
         vol.Required(CONF_ATTRIBUTE): cv.string,
         vol.Required(CONF_ENTITIES): cv.entity_ids,
     }
@@ -196,6 +198,13 @@ async def async_setup_platform(
             _LOGGER.debug("No icon applied")
             new_icon = None
 
+        unique_id = config.get(CONF_UNIQUE_ID, None)
+        if unique_id:
+            # If unique_id is provided, use it with entity suffix to ensure
+            # uniqueness
+            unique_id = slugify(
+                f"{unique_id}_{device.split('.', 1)[1]}_{attr}")
+
         sensors.append(
             AttributeSensor(
                 hass,
@@ -208,6 +217,7 @@ async def async_setup_platform(
                 state_template,
                 new_icon,
                 device,
+                unique_id,
             )
         )
     if not sensors:
@@ -233,6 +243,7 @@ class AttributeSensor(RestoreSensor):
         state_template,
         icon_template,
         entity_id,
+        unique_id=None,
     ):
         """Initialize the sensor."""
         super().__init__()
@@ -246,7 +257,8 @@ class AttributeSensor(RestoreSensor):
             else device_friendly_name
         )
         self._friendly_name = friendly_name
-        self._unique_id = slugify(f"{entity_id}_{device_id}")
+        self._unique_id = unique_id if unique_id else slugify(
+            f"{entity_id}_{device_id}")
         self._attr_device_class = device_class
         self._attr_state_class = state_class
         self._attr_native_unit_of_measurement = unit_of_measurement


### PR DESCRIPTION
## Description
This PR adds support for a configurable `unique_id` option for attribute sensors. Previously, the unique ID was automatically generated from the entity ID and device ID, but now users can specify a custom prefix.

## Changes
- Added `unique_id` as an optional configuration parameter
- When provided, the unique_id is used as a prefix: `{unique_id}_{entity_name}_{attribute}`
- Falls back to the original auto-generated format if not specified (backward compatible)
- Uses `CONF_UNIQUE_ID` constant from `homeassistant.const`

## Usage Example
```yaml
sensor:
  - platform: attributes
    unique_id: "my_custom_prefix"
    attribute: battery_level
    entities:
      - sensor.myslipo_1_0
      - sensor.myslipo_2_0
```

This will create sensors with unique IDs like:
- `my_custom_prefix_myslipo_1_0_battery_level`
- `my_custom_prefix_myslipo_2_0_battery_level`

## Backward Compatibility
✅ Fully backward compatible - existing configurations will continue to work without any changes.