### PR TITLE
fix: handle None attribute values to prevent ValueError

### DIFF
--- a/custom_components/attributes/sensor.py
+++ b/custom_components/attributes/sensor.py
@@ -75,7 +75,8 @@ async def async_setup_platform(
 
             state_template = (
                 "{{% if states('{0}') != '{3}' "
-                "and states('{0}') != '{4}' %}}"
+                "and states('{0}') != '{4}' "
+                "and state_attr('{0}', '{1}') is not none %}}"
                 "{{{{ as_timestamp(state_attr('{0}', '{1}'))"
                 "| int | timestamp_local()"
                 "| timestamp_custom('{2}') }}}}"
@@ -89,7 +90,8 @@ async def async_setup_platform(
 
             state_template = (
                 "{{% if states('{0}') != '{2}' "
-                "and states('{0}') != '{5}' %}}"
+                "and states('{0}') != '{5}' "
+                "and state_attr('{0}', '{1}') is not none %}}"
             )
 
             if round_to is None:


### PR DESCRIPTION
## Summary
- Fixes `ValueError: Template error: float got invalid input 'None'` when an entity attribute returns `None`
- Adds `state_attr() is not none` check to all template variants (time-based and value-based)
- When the attribute is `None`, the sensor now gracefully falls back to `unknown` instead of crashing

Closes #46

## Test plan
- [ ] Configure a sensor with `round_to` pointing to an entity whose attribute can be `None`
- [ ] Verify the sensor shows `unknown` instead of throwing a `ValueError`
- [ ] Verify normal operation is unaffected when the attribute has a valid value

🤖 Generated with [Claude Code](https://claude.com/claude-code)