### PR TITLE
feat: changed base class from RestoreEntity to RestoreSensor

### DIFF
--- a/custom_components/attributes/manifest.json
+++ b/custom_components/attributes/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "assumed_state",
   "issue_tracker": "https://github.com/pilotak/homeassistant-attributes/issues",
   "requirements": [],
-  "version": "1.3.2"
+  "version": "1.4.0"
 }

--- a/custom_components/attributes/sensor.py
+++ b/custom_components/attributes/sensor.py
@@ -34,7 +34,7 @@ from homeassistant.helpers import template as template_helper
 from homeassistant.util import slugify
 
 
-__version__ = "1.3.3"
+__version__ = "1.4.0"
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/attributes/sensor.py
+++ b/custom_components/attributes/sensor.py
@@ -249,6 +249,7 @@ class AttributeSensor(RestoreSensor):
         self._attr_device_class = device_class
         self._attr_state_class = state_class
         self._attr_native_unit_of_measurement = unit_of_measurement
+        self._attr_suggested_unit_of_measurement = unit_of_measurement
         self._template = state_template
         self._state = None
         self._icon_template = icon_template

--- a/custom_components/attributes/sensor.py
+++ b/custom_components/attributes/sensor.py
@@ -13,6 +13,7 @@ from homeassistant.components.sensor import (
     DEVICE_CLASSES_SCHEMA,
     STATE_CLASSES_SCHEMA,
     CONF_STATE_CLASS,
+    RestoreSensor,
 )
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
@@ -29,12 +30,11 @@ from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.event import async_track_state_change_event
-from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers import template as template_helper
 from homeassistant.util import slugify
 
 
-__version__ = "1.3.2"
+__version__ = "1.3.3"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -217,7 +217,7 @@ async def async_setup_platform(
     return True
 
 
-class AttributeSensor(RestoreEntity):
+class AttributeSensor(RestoreSensor):
     """Representation of a Attribute Sensor."""
 
     def __init__(
@@ -234,6 +234,7 @@ class AttributeSensor(RestoreEntity):
         entity_id,
     ):
         """Initialize the sensor."""
+        super().__init__()
         self.hass = hass
         self.entity_id = async_generate_entity_id(
             ENTITY_ID_FORMAT, device_id, hass=hass
@@ -247,7 +248,7 @@ class AttributeSensor(RestoreEntity):
         self._unique_id = slugify(f"{entity_id}_{device_id}")
         self._attr_device_class = device_class
         self._attr_state_class = state_class
-        self._unit_of_measurement = unit_of_measurement
+        self._attr_native_unit_of_measurement = unit_of_measurement
         self._template = state_template
         self._state = None
         self._icon_template = icon_template
@@ -256,6 +257,7 @@ class AttributeSensor(RestoreEntity):
 
     async def async_added_to_hass(self):
         """Register callbacks."""
+        await super().async_added_to_hass()
         state = await self.async_get_last_state()
         if state:
             self._state = state.state
@@ -289,7 +291,7 @@ class AttributeSensor(RestoreEntity):
         return self._unique_id
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor."""
         return self._state
 
@@ -297,16 +299,6 @@ class AttributeSensor(RestoreEntity):
     def icon(self):
         """Return the icon to use in the frontend, if any."""
         return self._icon
-
-    @property
-    def state_class(self):
-        """Return the state class of the sensor."""
-        return self._attr_state_class
-
-    @property
-    def unit_of_measurement(self):
-        """Return the native unit of measurement of the device."""
-        return self._unit_of_measurement
 
     @property
     def available(self):

--- a/custom_components/attributes/sensor.py
+++ b/custom_components/attributes/sensor.py
@@ -149,8 +149,7 @@ async def async_setup_platform(
                 "mdi:eye {{% endif %}}"
             ).format(device, icon, STATE_UNKNOWN, STATE_UNAVAILABLE)
 
-            new_icon = template_helper.Template(new_icon)
-            new_icon.hass = hass
+            new_icon = template_helper.Template(new_icon, hass)
         elif (
             (device_class is None or device_class != "battery")
             and attr == "battery"


### PR DESCRIPTION
Closes #59. Supersedes #61.

The previous fix attempts (1.3.1 / 1.3.2) added a `state_class` property on `AttributeSensor`, but `AttributeSensor` inherited from `RestoreEntity`, which is not a `SensorEntity`. Sensor-specific attributes are only exposed to the frontend when the entity inherits from `SensorEntity`, so the property had no effect. This PR switches the base class to `RestoreSensor` (= `SensorEntity` + `RestoreEntity`) and adapts the entity to the standard sensor API (`native_value`, `_attr_native_unit_of_measurement`).

#61 had the right idea but its diff was unmergeable: the GitHub web Copilot editor flipped the file's line endings from CRLF to LF, producing a +363/-371 churn diff that obscured the actual ~10 lines of conceptual change. I closed it in favor of this PR which cherry-picks @sfedotovs's commit (preserving him as commit author for the core fix), rewrites the file with the original CRLF line endings so the diff is clean, and additionally sets `_attr_suggested_unit_of_measurement` so the user-configured unit string is displayed verbatim regardless of the user's HA unit system.